### PR TITLE
BUG FIX: fix divide by zero error

### DIFF
--- a/src/AbstractServerList.h
+++ b/src/AbstractServerList.h
@@ -59,7 +59,7 @@ class ServerDetails {
         , serviceLocator()
         , session()
         , services()
-        , expectedReadMBytesPerSec()
+        , expectedReadMBytesPerSec(DEFAULT_EXPECTED_READ_MBYTES_PER_SEC)
         , status(ServerStatus::REMOVE)
         , replicationId(0)
     {}
@@ -73,7 +73,7 @@ class ServerDetails {
         , serviceLocator()
         , session()
         , services()
-        , expectedReadMBytesPerSec()
+        , expectedReadMBytesPerSec(DEFAULT_EXPECTED_READ_MBYTES_PER_SEC)
         , status(status)
         , replicationId(replicationId)
     {}
@@ -183,6 +183,11 @@ class ServerDetails {
      * services.has(BACKUP_SERVICE), invalid otherwise.
      */
     uint32_t expectedReadMBytesPerSec;
+
+    /**
+     * Default expected disk bandwidth (typically overwritten by disc benchmark on init).
+     */
+    static const uint32_t DEFAULT_EXPECTED_READ_MBYTES_PER_SEC = 1024;
 
     /**
      * Whether this server is believed to be up, crashed, or down.


### PR DESCRIPTION
For arcane reasons, RAMCloud needs to run a disk benchmark before it is capable of maintaining a backup (even in memory).  The basic issue is that it governs its backup “sync to disc” timing based on how fast the disc in question actually is.  However, the in memory backup never calls this benchmark method because there is no disc in question to call it on.  The effect of skipping the benchmark method is to create a repeated divide by zero error in the backup sync logic (due to the fact that the expectedReadMBytesPerSecz value is zero by default).  For some reason the arithmetic exception is caught and the loop restarts, essentially burning an entire CPU core in an endless (and un-logged) error loop.